### PR TITLE
run maven install in the root directory

### DIFF
--- a/Dockerfile-python
+++ b/Dockerfile-python
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN pip3 install pipenv
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
 ENV PATH "/root/.poetry/bin:/root/.pyenv/bin:$PATH"
 

--- a/entrypoints/maven.sh
+++ b/entrypoints/maven.sh
@@ -30,7 +30,7 @@ snyk_pomfile(){
   else
     # something there
     
-    (mvn install) &>> "${SNYK_LOG_FILE}"
+    (mvn install -DskipTests -Dscope=runtime) &>> "${SNYK_LOG_FILE}"
 
   fi
 
@@ -55,6 +55,13 @@ maven::main() {
   set -o noglob
   readarray -t pomfiles < <(find "${SNYK_TARGET}" -type f -name "pom.xml" $SNYK_IGNORES )
   set +o noglob
+
+  # Run a maven install in the root of the directory
+  # This helps when scanning projects that use modules
+
+  if [[ -f "$SNYK_TARGET/pom.xml" ]]; then
+      mvn install --file="$SNYK_TARGET/pom.xml" -DskipTests -Denforcer.fail=false -Dscope=runtime --fail-at-end
+  fi
 
   for pomfile in "${pomfiles[@]}"; do
     snyk_pomfile "${pomfile}"


### PR DESCRIPTION
When scanning a maven project, start by running `mvn install` in the root directory so that modules will be built. Otherwise it runs into errors if it tries to scan those first.

Also, use the flags `-DskipTests -Dscope=runtime` so that we don't run tests (which we don't care about for using snyk) and to exclude provided scope dependencies.