### PR TITLE
Feat/python version workaround

### DIFF
--- a/entrypoints/python.sh
+++ b/entrypoints/python.sh
@@ -47,6 +47,8 @@ snyk_pipfile(){
   
     declare -xg PIPENV_NOSPIN=1 PIPENV_COLORBLIND=1 PIPENV_QUIET=1 PIP_QUIET=1 PIPENV_HIDE_EMOJIS=1
     
+    sed -i '/python_version/d' Pipfile
+
     if [[ -f "Pipfile.lock" ]]; then
       (pipenv sync ) &>> "${SNYK_LOG_FILE}"
     else


### PR DESCRIPTION
Scans were failing if the python version used in the container wasn't an exact match for the version specified in the Pipfile. As a workaround, this will remove the python_version line from the Pipfile before starting the scan.