### PR TITLE
Feat/npm workspace support

### DIFF
--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,7 +1,7 @@
 FROM node:lts-buster-slim
 
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y curl jq && \
     apt-get upgrade -y && \
     apt-get autoremove -y && \
     apt-get clean && \

--- a/Dockerfile-python
+++ b/Dockerfile-python
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN pip3 install pipenv
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
 ENV PATH "/root/.poetry/bin:/root/.pyenv/bin:$PATH"
 

--- a/entrypoints/maven.sh
+++ b/entrypoints/maven.sh
@@ -30,7 +30,7 @@ snyk_pomfile(){
   else
     # something there
     
-    (mvn install -DskipTests -Dscope=runtime) &>> "${SNYK_LOG_FILE}"
+    (mvn install) &>> "${SNYK_LOG_FILE}"
 
   fi
 
@@ -55,13 +55,6 @@ maven::main() {
   set -o noglob
   readarray -t pomfiles < <(find "${SNYK_TARGET}" -type f -name "pom.xml" $SNYK_IGNORES )
   set +o noglob
-
-  # Run a maven install in the root of the directory
-  # This helps when scanning projects that use modules
-
-  if [[ -f "$SNYK_TARGET/pom.xml" ]]; then
-      mvn install --file="$SNYK_TARGET/pom.xml" -DskipTests -Denforcer.fail=false -Dscope=runtime --fail-at-end
-  fi
 
   for pomfile in "${pomfiles[@]}"; do
     snyk_pomfile "${pomfile}"

--- a/entrypoints/maven.sh
+++ b/entrypoints/maven.sh
@@ -30,7 +30,7 @@ snyk_pomfile(){
   else
     # something there
     
-    (mvn install) &>> "${SNYK_LOG_FILE}"
+    (mvn install -DskipTests -Dscope=runtime) &>> "${SNYK_LOG_FILE}"
 
   fi
 
@@ -55,6 +55,13 @@ maven::main() {
   set -o noglob
   readarray -t pomfiles < <(find "${SNYK_TARGET}" -type f -name "pom.xml" $SNYK_IGNORES )
   set +o noglob
+
+  # Run a maven install in the root of the directory
+  # This helps when scanning projects that use modules
+
+  if [[ -f "$SNYK_TARGET/pom.xml" ]]; then
+      mvn install --file="$SNYK_TARGET/pom.xml" -DskipTests -Denforcer.fail=false -Dscope=runtime --fail-at-end
+  fi
 
   for pomfile in "${pomfiles[@]}"; do
     snyk_pomfile "${pomfile}"

--- a/entrypoints/node.sh
+++ b/entrypoints/node.sh
@@ -146,7 +146,7 @@ node::main() {
       cd "${targetdir}"
   done
 
-  # check if any yarn projects are workspaces and prep with hard links
+  # check if npm projects are workspaces and create empty node_modules folders
   for packagefile in "${packages[@]}"; do
     prep_for_node_workspaces "${packagefile}"
       cd "${targetdir}"

--- a/entrypoints/node.sh
+++ b/entrypoints/node.sh
@@ -94,6 +94,31 @@ prep_for_yarn_workspaces() {
   fi
 }
 
+prep_for_node_workspaces() {
+  local manifest
+  manifest=$(basename "$1")
+  local project_path
+  project_path=$(dirname "$1")
+
+  cd "${project_path}" || exit
+
+  node_workspaces_result=$(npm --workspaces list --json)
+  node_workspaces_return_code=$?
+
+  if [[ $node_workspaces_return_code -gt 0 ]]; then
+    # probably not a node workspace project
+    # let's go back to the root directory
+    break
+  else # this is node workspace project
+    #create an empty node_modules folder
+
+    readarray -t node_workspaces_result < <(echo "${node_workspaces_result}" | jq -r '.dependencies | keys | .[]')
+    for packagedir in "${node_workspaces_result[@]}"; do
+      [ -d $packagedir ] && mkdir $packagedir/node_modules
+    done
+  fi
+}
+
 node::main() {
   declare -x SNYK_LOG_FILE
 
@@ -118,6 +143,12 @@ node::main() {
   # check if any yarn projects are workspaces and prep with hard links
   for yarnfile in "${yarnfiles[@]}"; do
     prep_for_yarn_workspaces "${yarnfile}"
+      cd "${targetdir}"
+  done
+
+  # check if any yarn projects are workspaces and prep with hard links
+  for packagefile in "${packages[@]}"; do
+    prep_for_node_workspaces "${packagefile}"
       cd "${targetdir}"
   done
 

--- a/testrepo/node_workspaces/node_modules/.package-lock.json
+++ b/testrepo/node_workspaces/node_modules/.package-lock.json
@@ -1,0 +1,44 @@
+{
+  "name": "node_workspaces",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.2.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      }
+    },
+    "node_modules/workspace-a": {
+      "resolved": "workspace-a",
+      "link": true
+    },
+    "node_modules/workspace-b": {
+      "resolved": "workspace-b",
+      "link": true
+    },
+    "workspace-a": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      }
+    },
+    "workspace-b": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {}
+    }
+  }
+}

--- a/testrepo/node_workspaces/node_modules/abbrev/LICENSE
+++ b/testrepo/node_workspaces/node_modules/abbrev/LICENSE
@@ -1,0 +1,46 @@
+This software is dual-licensed under the ISC and MIT licenses.
+You may use this software under EITHER of the following licenses.
+
+----------
+
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----------
+
+Copyright Isaac Z. Schlueter and Contributors
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/testrepo/node_workspaces/node_modules/abbrev/README.md
+++ b/testrepo/node_workspaces/node_modules/abbrev/README.md
@@ -1,0 +1,23 @@
+# abbrev-js
+
+Just like [ruby's Abbrev](http://apidock.com/ruby/Abbrev).
+
+Usage:
+
+    var abbrev = require("abbrev");
+    abbrev("foo", "fool", "folding", "flop");
+    
+    // returns:
+    { fl: 'flop'
+    , flo: 'flop'
+    , flop: 'flop'
+    , fol: 'folding'
+    , fold: 'folding'
+    , foldi: 'folding'
+    , foldin: 'folding'
+    , folding: 'folding'
+    , foo: 'foo'
+    , fool: 'fool'
+    }
+
+This is handy for command-line scripts, or other cases where you want to be able to accept shorthands.

--- a/testrepo/node_workspaces/node_modules/abbrev/lib/index.js
+++ b/testrepo/node_workspaces/node_modules/abbrev/lib/index.js
@@ -1,0 +1,50 @@
+module.exports = abbrev
+
+function abbrev (...args) {
+  let list = args.length === 1 || Array.isArray(args[0]) ? args[0] : args
+
+  for (let i = 0, l = list.length; i < l; i++) {
+    list[i] = typeof list[i] === 'string' ? list[i] : String(list[i])
+  }
+
+  // sort them lexicographically, so that they're next to their nearest kin
+  list = list.sort(lexSort)
+
+  // walk through each, seeing how much it has in common with the next and previous
+  const abbrevs = {}
+  let prev = ''
+  for (let ii = 0, ll = list.length; ii < ll; ii++) {
+    const current = list[ii]
+    const next = list[ii + 1] || ''
+    let nextMatches = true
+    let prevMatches = true
+    if (current === next) {
+      continue
+    }
+    let j = 0
+    const cl = current.length
+    for (; j < cl; j++) {
+      const curChar = current.charAt(j)
+      nextMatches = nextMatches && curChar === next.charAt(j)
+      prevMatches = prevMatches && curChar === prev.charAt(j)
+      if (!nextMatches && !prevMatches) {
+        j++
+        break
+      }
+    }
+    prev = current
+    if (j === cl) {
+      abbrevs[current] = current
+      continue
+    }
+    for (let a = current.slice(0, j); j <= cl; j++) {
+      abbrevs[a] = current
+      a += current.charAt(j)
+    }
+  }
+  return abbrevs
+}
+
+function lexSort (a, b) {
+  return a === b ? 0 : a > b ? 1 : -1
+}

--- a/testrepo/node_workspaces/node_modules/abbrev/package.json
+++ b/testrepo/node_workspaces/node_modules/abbrev/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "abbrev",
+  "version": "2.0.0",
+  "description": "Like ruby's abbrev module, but in js",
+  "author": "GitHub Inc.",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "tap",
+    "lint": "eslint \"**/*.js\"",
+    "postlint": "template-oss-check",
+    "template-oss-apply": "template-oss-apply --force",
+    "lintfix": "npm run lint -- --fix",
+    "snap": "tap",
+    "posttest": "npm run lint"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/abbrev-js.git"
+  },
+  "license": "ISC",
+  "devDependencies": {
+    "@npmcli/eslint-config": "^4.0.0",
+    "@npmcli/template-oss": "4.8.0",
+    "tap": "^16.3.0"
+  },
+  "tap": {
+    "nyc-arg": [
+      "--exclude",
+      "tap-snapshots/**"
+    ]
+  },
+  "files": [
+    "bin/",
+    "lib/"
+  ],
+  "engines": {
+    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+  },
+  "templateOSS": {
+    "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
+    "version": "4.8.0"
+  }
+}

--- a/testrepo/node_workspaces/node_modules/chalk/license
+++ b/testrepo/node_workspaces/node_modules/chalk/license
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/testrepo/node_workspaces/node_modules/chalk/package.json
+++ b/testrepo/node_workspaces/node_modules/chalk/package.json
@@ -1,0 +1,81 @@
+{
+	"name": "chalk",
+	"version": "5.2.0",
+	"description": "Terminal string styling done right",
+	"license": "MIT",
+	"repository": "chalk/chalk",
+	"funding": "https://github.com/chalk/chalk?sponsor=1",
+	"type": "module",
+	"main": "./source/index.js",
+	"exports": "./source/index.js",
+	"imports": {
+		"#ansi-styles": "./source/vendor/ansi-styles/index.js",
+		"#supports-color": {
+			"node": "./source/vendor/supports-color/index.js",
+			"default": "./source/vendor/supports-color/browser.js"
+		}
+	},
+	"types": "./source/index.d.ts",
+	"engines": {
+		"node": "^12.17.0 || ^14.13 || >=16.0.0"
+	},
+	"scripts": {
+		"test": "xo && c8 ava && tsd",
+		"bench": "matcha benchmark.js"
+	},
+	"files": [
+		"source",
+		"!source/index.test-d.ts"
+	],
+	"keywords": [
+		"color",
+		"colour",
+		"colors",
+		"terminal",
+		"console",
+		"cli",
+		"string",
+		"ansi",
+		"style",
+		"styles",
+		"tty",
+		"formatting",
+		"rgb",
+		"256",
+		"shell",
+		"xterm",
+		"log",
+		"logging",
+		"command-line",
+		"text"
+	],
+	"devDependencies": {
+		"@types/node": "^16.11.10",
+		"ava": "^3.15.0",
+		"c8": "^7.10.0",
+		"color-convert": "^2.0.1",
+		"execa": "^6.0.0",
+		"log-update": "^5.0.0",
+		"matcha": "^0.7.0",
+		"tsd": "^0.19.0",
+		"xo": "^0.53.0",
+		"yoctodelay": "^2.0.0"
+	},
+	"xo": {
+		"rules": {
+			"unicorn/prefer-string-slice": "off",
+			"@typescript-eslint/consistent-type-imports": "off",
+			"@typescript-eslint/consistent-type-exports": "off",
+			"@typescript-eslint/consistent-type-definitions": "off"
+		}
+	},
+	"c8": {
+		"reporter": [
+			"text",
+			"lcov"
+		],
+		"exclude": [
+			"source/vendor"
+		]
+	}
+}

--- a/testrepo/node_workspaces/node_modules/chalk/readme.md
+++ b/testrepo/node_workspaces/node_modules/chalk/readme.md
@@ -1,0 +1,325 @@
+<h1 align="center">
+	<br>
+	<br>
+	<img width="320" src="media/logo.svg" alt="Chalk">
+	<br>
+	<br>
+	<br>
+</h1>
+
+> Terminal string styling done right
+
+[![Coverage Status](https://codecov.io/gh/chalk/chalk/branch/main/graph/badge.svg)](https://codecov.io/gh/chalk/chalk)
+[![npm dependents](https://badgen.net/npm/dependents/chalk)](https://www.npmjs.com/package/chalk?activeTab=dependents)
+[![Downloads](https://badgen.net/npm/dt/chalk)](https://www.npmjs.com/package/chalk)
+[![run on repl.it](https://img.shields.io/badge/Run_on_Replit-f26207?logo=replit&logoColor=white)](https://repl.it/github/chalk/chalk)
+
+![](media/screenshot.png)
+
+<br>
+
+---
+
+<div align="center">
+	<p>
+		<p>
+			<sup>
+				Sindre Sorhus' open source work is supported by the community on <a href="https://github.com/sponsors/sindresorhus">GitHub Sponsors</a>
+			</sup>
+		</p>
+		<sup>Special thanks to:</sup>
+		<br>
+		<br>
+		<a href="https://standardresume.co/tech">
+			<img src="https://sindresorhus.com/assets/thanks/standard-resume-logo.svg" width="160">
+		</a>
+		<br>
+		<br>
+		<a href="https://retool.com/?utm_campaign=sindresorhus">
+			<img src="https://sindresorhus.com/assets/thanks/retool-logo.svg" width="230">
+		</a>
+		<br>
+		<br>
+		<a href="https://strapi.io/?ref=sindresorhus">
+			<div>
+				<img src="https://sindresorhus.com/assets/thanks/strapi-logo-white-bg.png" width="220" alt="Strapi">
+			</div>
+			<b>Strapi is the leading open-source headless CMS.</b>
+			<div>
+				<sup>It’s 100% JavaScript, fully customizable, and developer-first.</sup>
+			</div>
+		</a>
+		<br>
+		<br>
+		<a href="https://www.stackaid.us/?utm_campaign=sindre">
+			<div>
+				<img src="https://sindresorhus.com/assets/thanks/stackaid-logo.png" width="230" alt="StackAid">
+			</div>
+			<b>Fund your open source dependencies</b>
+		</a>
+		<br>
+		<br>
+	</p>
+</div>
+
+---
+
+<br>
+
+## Highlights
+
+- Expressive API
+- Highly performant
+- No dependencies
+- Ability to nest styles
+- [256/Truecolor color support](#256-and-truecolor-color-support)
+- Auto-detects color support
+- Doesn't extend `String.prototype`
+- Clean and focused
+- Actively maintained
+- [Used by ~86,000 packages](https://www.npmjs.com/browse/depended/chalk) as of October 4, 2022
+
+## Install
+
+```sh
+npm install chalk
+```
+
+**IMPORTANT:** Chalk 5 is ESM. If you want to use Chalk with TypeScript or a build tool, you will probably want to use Chalk 4 for now. [Read more.](https://github.com/chalk/chalk/releases/tag/v5.0.0)
+
+## Usage
+
+```js
+import chalk from 'chalk';
+
+console.log(chalk.blue('Hello world!'));
+```
+
+Chalk comes with an easy to use composable API where you just chain and nest the styles you want.
+
+```js
+import chalk from 'chalk';
+
+const log = console.log;
+
+// Combine styled and normal strings
+log(chalk.blue('Hello') + ' World' + chalk.red('!'));
+
+// Compose multiple styles using the chainable API
+log(chalk.blue.bgRed.bold('Hello world!'));
+
+// Pass in multiple arguments
+log(chalk.blue('Hello', 'World!', 'Foo', 'bar', 'biz', 'baz'));
+
+// Nest styles
+log(chalk.red('Hello', chalk.underline.bgBlue('world') + '!'));
+
+// Nest styles of the same type even (color, underline, background)
+log(chalk.green(
+	'I am a green line ' +
+	chalk.blue.underline.bold('with a blue substring') +
+	' that becomes green again!'
+));
+
+// ES2015 template literal
+log(`
+CPU: ${chalk.red('90%')}
+RAM: ${chalk.green('40%')}
+DISK: ${chalk.yellow('70%')}
+`);
+
+// Use RGB colors in terminal emulators that support it.
+log(chalk.rgb(123, 45, 67).underline('Underlined reddish color'));
+log(chalk.hex('#DEADED').bold('Bold gray!'));
+```
+
+Easily define your own themes:
+
+```js
+import chalk from 'chalk';
+
+const error = chalk.bold.red;
+const warning = chalk.hex('#FFA500'); // Orange color
+
+console.log(error('Error!'));
+console.log(warning('Warning!'));
+```
+
+Take advantage of console.log [string substitution](https://nodejs.org/docs/latest/api/console.html#console_console_log_data_args):
+
+```js
+import chalk from 'chalk';
+
+const name = 'Sindre';
+console.log(chalk.green('Hello %s'), name);
+//=> 'Hello Sindre'
+```
+
+## API
+
+### chalk.`<style>[.<style>...](string, [string...])`
+
+Example: `chalk.red.bold.underline('Hello', 'world');`
+
+Chain [styles](#styles) and call the last one as a method with a string argument. Order doesn't matter, and later styles take precedent in case of a conflict. This simply means that `chalk.red.yellow.green` is equivalent to `chalk.green`.
+
+Multiple arguments will be separated by space.
+
+### chalk.level
+
+Specifies the level of color support.
+
+Color support is automatically detected, but you can override it by setting the `level` property. You should however only do this in your own code as it applies globally to all Chalk consumers.
+
+If you need to change this in a reusable module, create a new instance:
+
+```js
+import {Chalk} from 'chalk';
+
+const customChalk = new Chalk({level: 0});
+```
+
+| Level | Description |
+| :---: | :--- |
+| `0` | All colors disabled |
+| `1` | Basic color support (16 colors) |
+| `2` | 256 color support |
+| `3` | Truecolor support (16 million colors) |
+
+### supportsColor
+
+Detect whether the terminal [supports color](https://github.com/chalk/supports-color). Used internally and handled for you, but exposed for convenience.
+
+Can be overridden by the user with the flags `--color` and `--no-color`. For situations where using `--color` is not possible, use the environment variable `FORCE_COLOR=1` (level 1), `FORCE_COLOR=2` (level 2), or `FORCE_COLOR=3` (level 3) to forcefully enable color, or `FORCE_COLOR=0` to forcefully disable. The use of `FORCE_COLOR` overrides all other color support checks.
+
+Explicit 256/Truecolor mode can be enabled using the `--color=256` and `--color=16m` flags, respectively.
+
+### chalkStderr and supportsColorStderr
+
+`chalkStderr` contains a separate instance configured with color support detected for `stderr` stream instead of `stdout`. Override rules from `supportsColor` apply to this too. `supportsColorStderr` is exposed for convenience.
+
+### modifierNames, foregroundColorNames, backgroundColorNames, and colorNames
+
+All supported style strings are exposed as an array of strings for convenience. `colorNames` is the combination of `foregroundColorNames` and `backgroundColorNames`.
+
+This can be useful if you wrap Chalk and need to validate input:
+
+```js
+import {modifierNames, foregroundColorNames} from 'chalk';
+
+console.log(modifierNames.includes('bold'));
+//=> true
+
+console.log(foregroundColorNames.includes('pink'));
+//=> false
+```
+
+## Styles
+
+### Modifiers
+
+- `reset` - Reset the current style.
+- `bold` - Make the text bold.
+- `dim` - Make the text have lower opacity.
+- `italic` - Make the text italic. *(Not widely supported)*
+- `underline` - Put a horizontal line below the text. *(Not widely supported)*
+- `overline` - Put a horizontal line above the text. *(Not widely supported)*
+- `inverse`- Invert background and foreground colors.
+- `hidden` - Print the text but make it invisible.
+- `strikethrough` - Puts a horizontal line through the center of the text. *(Not widely supported)*
+- `visible`- Print the text only when Chalk has a color level above zero. Can be useful for things that are purely cosmetic.
+
+### Colors
+
+- `black`
+- `red`
+- `green`
+- `yellow`
+- `blue`
+- `magenta`
+- `cyan`
+- `white`
+- `blackBright` (alias: `gray`, `grey`)
+- `redBright`
+- `greenBright`
+- `yellowBright`
+- `blueBright`
+- `magentaBright`
+- `cyanBright`
+- `whiteBright`
+
+### Background colors
+
+- `bgBlack`
+- `bgRed`
+- `bgGreen`
+- `bgYellow`
+- `bgBlue`
+- `bgMagenta`
+- `bgCyan`
+- `bgWhite`
+- `bgBlackBright` (alias: `bgGray`, `bgGrey`)
+- `bgRedBright`
+- `bgGreenBright`
+- `bgYellowBright`
+- `bgBlueBright`
+- `bgMagentaBright`
+- `bgCyanBright`
+- `bgWhiteBright`
+
+## 256 and Truecolor color support
+
+Chalk supports 256 colors and [Truecolor](https://github.com/termstandard/colors) (16 million colors) on supported terminal apps.
+
+Colors are downsampled from 16 million RGB values to an ANSI color format that is supported by the terminal emulator (or by specifying `{level: n}` as a Chalk option). For example, Chalk configured to run at level 1 (basic color support) will downsample an RGB value of #FF0000 (red) to 31 (ANSI escape for red).
+
+Examples:
+
+- `chalk.hex('#DEADED').underline('Hello, world!')`
+- `chalk.rgb(15, 100, 204).inverse('Hello!')`
+
+Background versions of these models are prefixed with `bg` and the first level of the module capitalized (e.g. `hex` for foreground colors and `bgHex` for background colors).
+
+- `chalk.bgHex('#DEADED').underline('Hello, world!')`
+- `chalk.bgRgb(15, 100, 204).inverse('Hello!')`
+
+The following color models can be used:
+
+- [`rgb`](https://en.wikipedia.org/wiki/RGB_color_model) - Example: `chalk.rgb(255, 136, 0).bold('Orange!')`
+- [`hex`](https://en.wikipedia.org/wiki/Web_colors#Hex_triplet) - Example: `chalk.hex('#FF8800').bold('Orange!')`
+- [`ansi256`](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) - Example: `chalk.bgAnsi256(194)('Honeydew, more or less')`
+
+## Browser support
+
+Since Chrome 69, ANSI escape codes are natively supported in the developer console.
+
+## Windows
+
+If you're on Windows, do yourself a favor and use [Windows Terminal](https://github.com/microsoft/terminal) instead of `cmd.exe`.
+
+## Origin story
+
+[colors.js](https://github.com/Marak/colors.js) used to be the most popular string styling module, but it has serious deficiencies like extending `String.prototype` which causes all kinds of [problems](https://github.com/yeoman/yo/issues/68) and the package is unmaintained. Although there are other packages, they either do too much or not enough. Chalk is a clean and focused alternative.
+
+## Related
+
+- [chalk-template](https://github.com/chalk/chalk-template) - [Tagged template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) support for this module
+- [chalk-cli](https://github.com/chalk/chalk-cli) - CLI for this module
+- [ansi-styles](https://github.com/chalk/ansi-styles) - ANSI escape codes for styling strings in the terminal
+- [supports-color](https://github.com/chalk/supports-color) - Detect whether a terminal supports color
+- [strip-ansi](https://github.com/chalk/strip-ansi) - Strip ANSI escape codes
+- [strip-ansi-stream](https://github.com/chalk/strip-ansi-stream) - Strip ANSI escape codes from a stream
+- [has-ansi](https://github.com/chalk/has-ansi) - Check if a string has ANSI escape codes
+- [ansi-regex](https://github.com/chalk/ansi-regex) - Regular expression for matching ANSI escape codes
+- [wrap-ansi](https://github.com/chalk/wrap-ansi) - Wordwrap a string with ANSI escape codes
+- [slice-ansi](https://github.com/chalk/slice-ansi) - Slice a string with ANSI escape codes
+- [color-convert](https://github.com/qix-/color-convert) - Converts colors between different models
+- [chalk-animation](https://github.com/bokub/chalk-animation) - Animate strings in the terminal
+- [gradient-string](https://github.com/bokub/gradient-string) - Apply color gradients to strings
+- [chalk-pipe](https://github.com/LitoMore/chalk-pipe) - Create chalk style schemes with simpler style strings
+- [terminal-link](https://github.com/sindresorhus/terminal-link) - Create clickable links in the terminal
+
+## Maintainers
+
+- [Sindre Sorhus](https://github.com/sindresorhus)
+- [Josh Junon](https://github.com/qix-)

--- a/testrepo/node_workspaces/node_modules/chalk/source/index.d.ts
+++ b/testrepo/node_workspaces/node_modules/chalk/source/index.d.ts
@@ -1,0 +1,320 @@
+// TODO: Make it this when TS suports that.
+// import {ModifierName, ForegroundColor, BackgroundColor, ColorName} from '#ansi-styles';
+// import {ColorInfo, ColorSupportLevel} from '#supports-color';
+import {ModifierName, ForegroundColorName, BackgroundColorName, ColorName} from './vendor/ansi-styles/index.js';
+import {ColorInfo, ColorSupportLevel} from './vendor/supports-color/index.js';
+
+export interface Options {
+	/**
+	Specify the color support for Chalk.
+
+	By default, color support is automatically detected based on the environment.
+
+	Levels:
+	- `0` - All colors disabled.
+	- `1` - Basic 16 colors support.
+	- `2` - ANSI 256 colors support.
+	- `3` - Truecolor 16 million colors support.
+	*/
+	readonly level?: ColorSupportLevel;
+}
+
+/**
+Return a new Chalk instance.
+*/
+export const Chalk: new (options?: Options) => ChalkInstance; // eslint-disable-line @typescript-eslint/naming-convention
+
+export interface ChalkInstance {
+	(...text: unknown[]): string;
+
+	/**
+	The color support for Chalk.
+
+	By default, color support is automatically detected based on the environment.
+
+	Levels:
+	- `0` - All colors disabled.
+	- `1` - Basic 16 colors support.
+	- `2` - ANSI 256 colors support.
+	- `3` - Truecolor 16 million colors support.
+	*/
+	level: ColorSupportLevel;
+
+	/**
+	Use RGB values to set text color.
+
+	@example
+	```
+	import chalk from 'chalk';
+
+	chalk.rgb(222, 173, 237);
+	```
+	*/
+	rgb: (red: number, green: number, blue: number) => this;
+
+	/**
+	Use HEX value to set text color.
+
+	@param color - Hexadecimal value representing the desired color.
+
+	@example
+	```
+	import chalk from 'chalk';
+
+	chalk.hex('#DEADED');
+	```
+	*/
+	hex: (color: string) => this;
+
+	/**
+	Use an [8-bit unsigned number](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) to set text color.
+
+	@example
+	```
+	import chalk from 'chalk';
+
+	chalk.ansi256(201);
+	```
+	*/
+	ansi256: (index: number) => this;
+
+	/**
+	Use RGB values to set background color.
+
+	@example
+	```
+	import chalk from 'chalk';
+
+	chalk.bgRgb(222, 173, 237);
+	```
+	*/
+	bgRgb: (red: number, green: number, blue: number) => this;
+
+	/**
+	Use HEX value to set background color.
+
+	@param color - Hexadecimal value representing the desired color.
+
+	@example
+	```
+	import chalk from 'chalk';
+
+	chalk.bgHex('#DEADED');
+	```
+	*/
+	bgHex: (color: string) => this;
+
+	/**
+	Use a [8-bit unsigned number](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) to set background color.
+
+	@example
+	```
+	import chalk from 'chalk';
+
+	chalk.bgAnsi256(201);
+	```
+	*/
+	bgAnsi256: (index: number) => this;
+
+	/**
+	Modifier: Reset the current style.
+	*/
+	readonly reset: this;
+
+	/**
+	Modifier: Make the text bold.
+	*/
+	readonly bold: this;
+
+	/**
+	Modifier: Make the text have lower opacity.
+	*/
+	readonly dim: this;
+
+	/**
+	Modifier: Make the text italic. *(Not widely supported)*
+	*/
+	readonly italic: this;
+
+	/**
+	Modifier: Put a horizontal line below the text. *(Not widely supported)*
+	*/
+	readonly underline: this;
+
+	/**
+	Modifier: Put a horizontal line above the text. *(Not widely supported)*
+	*/
+	readonly overline: this;
+
+	/**
+	Modifier: Invert background and foreground colors.
+	*/
+	readonly inverse: this;
+
+	/**
+	Modifier: Print the text but make it invisible.
+	*/
+	readonly hidden: this;
+
+	/**
+	Modifier: Puts a horizontal line through the center of the text. *(Not widely supported)*
+	*/
+	readonly strikethrough: this;
+
+	/**
+	Modifier: Print the text only when Chalk has a color level above zero.
+
+	Can be useful for things that are purely cosmetic.
+	*/
+	readonly visible: this;
+
+	readonly black: this;
+	readonly red: this;
+	readonly green: this;
+	readonly yellow: this;
+	readonly blue: this;
+	readonly magenta: this;
+	readonly cyan: this;
+	readonly white: this;
+
+	/*
+	Alias for `blackBright`.
+	*/
+	readonly gray: this;
+
+	/*
+	Alias for `blackBright`.
+	*/
+	readonly grey: this;
+
+	readonly blackBright: this;
+	readonly redBright: this;
+	readonly greenBright: this;
+	readonly yellowBright: this;
+	readonly blueBright: this;
+	readonly magentaBright: this;
+	readonly cyanBright: this;
+	readonly whiteBright: this;
+
+	readonly bgBlack: this;
+	readonly bgRed: this;
+	readonly bgGreen: this;
+	readonly bgYellow: this;
+	readonly bgBlue: this;
+	readonly bgMagenta: this;
+	readonly bgCyan: this;
+	readonly bgWhite: this;
+
+	/*
+	Alias for `bgBlackBright`.
+	*/
+	readonly bgGray: this;
+
+	/*
+	Alias for `bgBlackBright`.
+	*/
+	readonly bgGrey: this;
+
+	readonly bgBlackBright: this;
+	readonly bgRedBright: this;
+	readonly bgGreenBright: this;
+	readonly bgYellowBright: this;
+	readonly bgBlueBright: this;
+	readonly bgMagentaBright: this;
+	readonly bgCyanBright: this;
+	readonly bgWhiteBright: this;
+}
+
+/**
+Main Chalk object that allows to chain styles together.
+
+Call the last one as a method with a string argument.
+
+Order doesn't matter, and later styles take precedent in case of a conflict.
+
+This simply means that `chalk.red.yellow.green` is equivalent to `chalk.green`.
+*/
+declare const chalk: ChalkInstance;
+
+export const supportsColor: ColorInfo;
+
+export const chalkStderr: typeof chalk;
+export const supportsColorStderr: typeof supportsColor;
+
+export {
+	ModifierName, ForegroundColorName, BackgroundColorName, ColorName,
+	modifierNames, foregroundColorNames, backgroundColorNames, colorNames,
+// } from '#ansi-styles';
+} from './vendor/ansi-styles/index.js';
+
+export {
+	ColorInfo,
+	ColorSupport,
+	ColorSupportLevel,
+// } from '#supports-color';
+} from './vendor/supports-color/index.js';
+
+// TODO: Remove these aliases in the next major version
+/**
+@deprecated Use `ModifierName` instead.
+
+Basic modifier names.
+*/
+export type Modifiers = ModifierName;
+
+/**
+@deprecated Use `ForegroundColorName` instead.
+
+Basic foreground color names.
+
+[More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
+*/
+export type ForegroundColor = ForegroundColorName;
+
+/**
+@deprecated Use `BackgroundColorName` instead.
+
+Basic background color names.
+
+[More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
+*/
+export type BackgroundColor = BackgroundColorName;
+
+/**
+@deprecated Use `ColorName` instead.
+
+Basic color names. The combination of foreground and background color names.
+
+[More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
+*/
+export type Color = ColorName;
+
+/**
+@deprecated Use `modifierNames` instead.
+
+Basic modifier names.
+*/
+export const modifiers: readonly Modifiers[];
+
+/**
+@deprecated Use `foregroundColorNames` instead.
+
+Basic foreground color names.
+*/
+export const foregroundColors: readonly ForegroundColor[];
+
+/**
+@deprecated Use `backgroundColorNames` instead.
+
+Basic background color names.
+*/
+export const backgroundColors: readonly BackgroundColor[];
+
+/**
+@deprecated Use `colorNames` instead.
+
+Basic color names. The combination of foreground and background color names.
+*/
+export const colors: readonly Color[];
+
+export default chalk;

--- a/testrepo/node_workspaces/node_modules/chalk/source/index.js
+++ b/testrepo/node_workspaces/node_modules/chalk/source/index.js
@@ -1,0 +1,225 @@
+import ansiStyles from '#ansi-styles';
+import supportsColor from '#supports-color';
+import { // eslint-disable-line import/order
+	stringReplaceAll,
+	stringEncaseCRLFWithFirstIndex,
+} from './utilities.js';
+
+const {stdout: stdoutColor, stderr: stderrColor} = supportsColor;
+
+const GENERATOR = Symbol('GENERATOR');
+const STYLER = Symbol('STYLER');
+const IS_EMPTY = Symbol('IS_EMPTY');
+
+// `supportsColor.level` → `ansiStyles.color[name]` mapping
+const levelMapping = [
+	'ansi',
+	'ansi',
+	'ansi256',
+	'ansi16m',
+];
+
+const styles = Object.create(null);
+
+const applyOptions = (object, options = {}) => {
+	if (options.level && !(Number.isInteger(options.level) && options.level >= 0 && options.level <= 3)) {
+		throw new Error('The `level` option should be an integer from 0 to 3');
+	}
+
+	// Detect level if not set manually
+	const colorLevel = stdoutColor ? stdoutColor.level : 0;
+	object.level = options.level === undefined ? colorLevel : options.level;
+};
+
+export class Chalk {
+	constructor(options) {
+		// eslint-disable-next-line no-constructor-return
+		return chalkFactory(options);
+	}
+}
+
+const chalkFactory = options => {
+	const chalk = (...strings) => strings.join(' ');
+	applyOptions(chalk, options);
+
+	Object.setPrototypeOf(chalk, createChalk.prototype);
+
+	return chalk;
+};
+
+function createChalk(options) {
+	return chalkFactory(options);
+}
+
+Object.setPrototypeOf(createChalk.prototype, Function.prototype);
+
+for (const [styleName, style] of Object.entries(ansiStyles)) {
+	styles[styleName] = {
+		get() {
+			const builder = createBuilder(this, createStyler(style.open, style.close, this[STYLER]), this[IS_EMPTY]);
+			Object.defineProperty(this, styleName, {value: builder});
+			return builder;
+		},
+	};
+}
+
+styles.visible = {
+	get() {
+		const builder = createBuilder(this, this[STYLER], true);
+		Object.defineProperty(this, 'visible', {value: builder});
+		return builder;
+	},
+};
+
+const getModelAnsi = (model, level, type, ...arguments_) => {
+	if (model === 'rgb') {
+		if (level === 'ansi16m') {
+			return ansiStyles[type].ansi16m(...arguments_);
+		}
+
+		if (level === 'ansi256') {
+			return ansiStyles[type].ansi256(ansiStyles.rgbToAnsi256(...arguments_));
+		}
+
+		return ansiStyles[type].ansi(ansiStyles.rgbToAnsi(...arguments_));
+	}
+
+	if (model === 'hex') {
+		return getModelAnsi('rgb', level, type, ...ansiStyles.hexToRgb(...arguments_));
+	}
+
+	return ansiStyles[type][model](...arguments_);
+};
+
+const usedModels = ['rgb', 'hex', 'ansi256'];
+
+for (const model of usedModels) {
+	styles[model] = {
+		get() {
+			const {level} = this;
+			return function (...arguments_) {
+				const styler = createStyler(getModelAnsi(model, levelMapping[level], 'color', ...arguments_), ansiStyles.color.close, this[STYLER]);
+				return createBuilder(this, styler, this[IS_EMPTY]);
+			};
+		},
+	};
+
+	const bgModel = 'bg' + model[0].toUpperCase() + model.slice(1);
+	styles[bgModel] = {
+		get() {
+			const {level} = this;
+			return function (...arguments_) {
+				const styler = createStyler(getModelAnsi(model, levelMapping[level], 'bgColor', ...arguments_), ansiStyles.bgColor.close, this[STYLER]);
+				return createBuilder(this, styler, this[IS_EMPTY]);
+			};
+		},
+	};
+}
+
+const proto = Object.defineProperties(() => {}, {
+	...styles,
+	level: {
+		enumerable: true,
+		get() {
+			return this[GENERATOR].level;
+		},
+		set(level) {
+			this[GENERATOR].level = level;
+		},
+	},
+});
+
+const createStyler = (open, close, parent) => {
+	let openAll;
+	let closeAll;
+	if (parent === undefined) {
+		openAll = open;
+		closeAll = close;
+	} else {
+		openAll = parent.openAll + open;
+		closeAll = close + parent.closeAll;
+	}
+
+	return {
+		open,
+		close,
+		openAll,
+		closeAll,
+		parent,
+	};
+};
+
+const createBuilder = (self, _styler, _isEmpty) => {
+	// Single argument is hot path, implicit coercion is faster than anything
+	// eslint-disable-next-line no-implicit-coercion
+	const builder = (...arguments_) => applyStyle(builder, (arguments_.length === 1) ? ('' + arguments_[0]) : arguments_.join(' '));
+
+	// We alter the prototype because we must return a function, but there is
+	// no way to create a function with a different prototype
+	Object.setPrototypeOf(builder, proto);
+
+	builder[GENERATOR] = self;
+	builder[STYLER] = _styler;
+	builder[IS_EMPTY] = _isEmpty;
+
+	return builder;
+};
+
+const applyStyle = (self, string) => {
+	if (self.level <= 0 || !string) {
+		return self[IS_EMPTY] ? '' : string;
+	}
+
+	let styler = self[STYLER];
+
+	if (styler === undefined) {
+		return string;
+	}
+
+	const {openAll, closeAll} = styler;
+	if (string.includes('\u001B')) {
+		while (styler !== undefined) {
+			// Replace any instances already present with a re-opening code
+			// otherwise only the part of the string until said closing code
+			// will be colored, and the rest will simply be 'plain'.
+			string = stringReplaceAll(string, styler.close, styler.open);
+
+			styler = styler.parent;
+		}
+	}
+
+	// We can move both next actions out of loop, because remaining actions in loop won't have
+	// any/visible effect on parts we add here. Close the styling before a linebreak and reopen
+	// after next line to fix a bleed issue on macOS: https://github.com/chalk/chalk/pull/92
+	const lfIndex = string.indexOf('\n');
+	if (lfIndex !== -1) {
+		string = stringEncaseCRLFWithFirstIndex(string, closeAll, openAll, lfIndex);
+	}
+
+	return openAll + string + closeAll;
+};
+
+Object.defineProperties(createChalk.prototype, styles);
+
+const chalk = createChalk();
+export const chalkStderr = createChalk({level: stderrColor ? stderrColor.level : 0});
+
+export {
+	modifierNames,
+	foregroundColorNames,
+	backgroundColorNames,
+	colorNames,
+
+	// TODO: Remove these aliases in the next major version
+	modifierNames as modifiers,
+	foregroundColorNames as foregroundColors,
+	backgroundColorNames as backgroundColors,
+	colorNames as colors,
+} from './vendor/ansi-styles/index.js';
+
+export {
+	stdoutColor as supportsColor,
+	stderrColor as supportsColorStderr,
+};
+
+export default chalk;

--- a/testrepo/node_workspaces/node_modules/chalk/source/utilities.js
+++ b/testrepo/node_workspaces/node_modules/chalk/source/utilities.js
@@ -1,0 +1,33 @@
+// TODO: When targeting Node.js 16, use `String.prototype.replaceAll`.
+export function stringReplaceAll(string, substring, replacer) {
+	let index = string.indexOf(substring);
+	if (index === -1) {
+		return string;
+	}
+
+	const substringLength = substring.length;
+	let endIndex = 0;
+	let returnValue = '';
+	do {
+		returnValue += string.slice(endIndex, index) + substring + replacer;
+		endIndex = index + substringLength;
+		index = string.indexOf(substring, endIndex);
+	} while (index !== -1);
+
+	returnValue += string.slice(endIndex);
+	return returnValue;
+}
+
+export function stringEncaseCRLFWithFirstIndex(string, prefix, postfix, index) {
+	let endIndex = 0;
+	let returnValue = '';
+	do {
+		const gotCR = string[index - 1] === '\r';
+		returnValue += string.slice(endIndex, (gotCR ? index - 1 : index)) + prefix + (gotCR ? '\r\n' : '\n') + postfix;
+		endIndex = index + 1;
+		index = string.indexOf('\n', endIndex);
+	} while (index !== -1);
+
+	returnValue += string.slice(endIndex);
+	return returnValue;
+}

--- a/testrepo/node_workspaces/node_modules/chalk/source/vendor/ansi-styles/index.d.ts
+++ b/testrepo/node_workspaces/node_modules/chalk/source/vendor/ansi-styles/index.d.ts
@@ -1,0 +1,236 @@
+export interface CSPair { // eslint-disable-line @typescript-eslint/naming-convention
+	/**
+	The ANSI terminal control sequence for starting this style.
+	*/
+	readonly open: string;
+
+	/**
+	The ANSI terminal control sequence for ending this style.
+	*/
+	readonly close: string;
+}
+
+export interface ColorBase {
+	/**
+	The ANSI terminal control sequence for ending this color.
+	*/
+	readonly close: string;
+
+	ansi(code: number): string;
+
+	ansi256(code: number): string;
+
+	ansi16m(red: number, green: number, blue: number): string;
+}
+
+export interface Modifier {
+	/**
+	Resets the current color chain.
+	*/
+	readonly reset: CSPair;
+
+	/**
+	Make text bold.
+	*/
+	readonly bold: CSPair;
+
+	/**
+	Emitting only a small amount of light.
+	*/
+	readonly dim: CSPair;
+
+	/**
+	Make text italic. (Not widely supported)
+	*/
+	readonly italic: CSPair;
+
+	/**
+	Make text underline. (Not widely supported)
+	*/
+	readonly underline: CSPair;
+
+	/**
+	Make text overline.
+
+	Supported on VTE-based terminals, the GNOME terminal, mintty, and Git Bash.
+	*/
+	readonly overline: CSPair;
+
+	/**
+	Inverse background and foreground colors.
+	*/
+	readonly inverse: CSPair;
+
+	/**
+	Prints the text, but makes it invisible.
+	*/
+	readonly hidden: CSPair;
+
+	/**
+	Puts a horizontal line through the center of the text. (Not widely supported)
+	*/
+	readonly strikethrough: CSPair;
+}
+
+export interface ForegroundColor {
+	readonly black: CSPair;
+	readonly red: CSPair;
+	readonly green: CSPair;
+	readonly yellow: CSPair;
+	readonly blue: CSPair;
+	readonly cyan: CSPair;
+	readonly magenta: CSPair;
+	readonly white: CSPair;
+
+	/**
+	Alias for `blackBright`.
+	*/
+	readonly gray: CSPair;
+
+	/**
+	Alias for `blackBright`.
+	*/
+	readonly grey: CSPair;
+
+	readonly blackBright: CSPair;
+	readonly redBright: CSPair;
+	readonly greenBright: CSPair;
+	readonly yellowBright: CSPair;
+	readonly blueBright: CSPair;
+	readonly cyanBright: CSPair;
+	readonly magentaBright: CSPair;
+	readonly whiteBright: CSPair;
+}
+
+export interface BackgroundColor {
+	readonly bgBlack: CSPair;
+	readonly bgRed: CSPair;
+	readonly bgGreen: CSPair;
+	readonly bgYellow: CSPair;
+	readonly bgBlue: CSPair;
+	readonly bgCyan: CSPair;
+	readonly bgMagenta: CSPair;
+	readonly bgWhite: CSPair;
+
+	/**
+	Alias for `bgBlackBright`.
+	*/
+	readonly bgGray: CSPair;
+
+	/**
+	Alias for `bgBlackBright`.
+	*/
+	readonly bgGrey: CSPair;
+
+	readonly bgBlackBright: CSPair;
+	readonly bgRedBright: CSPair;
+	readonly bgGreenBright: CSPair;
+	readonly bgYellowBright: CSPair;
+	readonly bgBlueBright: CSPair;
+	readonly bgCyanBright: CSPair;
+	readonly bgMagentaBright: CSPair;
+	readonly bgWhiteBright: CSPair;
+}
+
+export interface ConvertColor {
+	/**
+	Convert from the RGB color space to the ANSI 256 color space.
+
+	@param red - (`0...255`)
+	@param green - (`0...255`)
+	@param blue - (`0...255`)
+	*/
+	rgbToAnsi256(red: number, green: number, blue: number): number;
+
+	/**
+	Convert from the RGB HEX color space to the RGB color space.
+
+	@param hex - A hexadecimal string containing RGB data.
+	*/
+	hexToRgb(hex: string): [red: number, green: number, blue: number];
+
+	/**
+	Convert from the RGB HEX color space to the ANSI 256 color space.
+
+	@param hex - A hexadecimal string containing RGB data.
+	*/
+	hexToAnsi256(hex: string): number;
+
+	/**
+	Convert from the ANSI 256 color space to the ANSI 16 color space.
+
+	@param code - A number representing the ANSI 256 color.
+	*/
+	ansi256ToAnsi(code: number): number;
+
+	/**
+	Convert from the RGB color space to the ANSI 16 color space.
+
+	@param red - (`0...255`)
+	@param green - (`0...255`)
+	@param blue - (`0...255`)
+	*/
+	rgbToAnsi(red: number, green: number, blue: number): number;
+
+	/**
+	Convert from the RGB HEX color space to the ANSI 16 color space.
+
+	@param hex - A hexadecimal string containing RGB data.
+	*/
+	hexToAnsi(hex: string): number;
+}
+
+/**
+Basic modifier names.
+*/
+export type ModifierName = keyof Modifier;
+
+/**
+Basic foreground color names.
+
+[More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
+*/
+export type ForegroundColorName = keyof ForegroundColor;
+
+/**
+Basic background color names.
+
+[More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
+*/
+export type BackgroundColorName = keyof BackgroundColor;
+
+/**
+Basic color names. The combination of foreground and background color names.
+
+[More colors here.](https://github.com/chalk/chalk/blob/main/readme.md#256-and-truecolor-color-support)
+*/
+export type ColorName = ForegroundColorName | BackgroundColorName;
+
+/**
+Basic modifier names.
+*/
+export const modifierNames: readonly ModifierName[];
+
+/**
+Basic foreground color names.
+*/
+export const foregroundColorNames: readonly ForegroundColorName[];
+
+/**
+Basic background color names.
+*/
+export const backgroundColorNames: readonly BackgroundColorName[];
+
+/*
+Basic color names. The combination of foreground and background color names.
+*/
+export const colorNames: readonly ColorName[];
+
+declare const ansiStyles: {
+	readonly modifier: Modifier;
+	readonly color: ColorBase & ForegroundColor;
+	readonly bgColor: ColorBase & BackgroundColor;
+	readonly codes: ReadonlyMap<number, number>;
+} & ForegroundColor & BackgroundColor & Modifier & ConvertColor;
+
+export default ansiStyles;

--- a/testrepo/node_workspaces/node_modules/chalk/source/vendor/ansi-styles/index.js
+++ b/testrepo/node_workspaces/node_modules/chalk/source/vendor/ansi-styles/index.js
@@ -1,0 +1,223 @@
+const ANSI_BACKGROUND_OFFSET = 10;
+
+const wrapAnsi16 = (offset = 0) => code => `\u001B[${code + offset}m`;
+
+const wrapAnsi256 = (offset = 0) => code => `\u001B[${38 + offset};5;${code}m`;
+
+const wrapAnsi16m = (offset = 0) => (red, green, blue) => `\u001B[${38 + offset};2;${red};${green};${blue}m`;
+
+const styles = {
+	modifier: {
+		reset: [0, 0],
+		// 21 isn't widely supported and 22 does the same thing
+		bold: [1, 22],
+		dim: [2, 22],
+		italic: [3, 23],
+		underline: [4, 24],
+		overline: [53, 55],
+		inverse: [7, 27],
+		hidden: [8, 28],
+		strikethrough: [9, 29],
+	},
+	color: {
+		black: [30, 39],
+		red: [31, 39],
+		green: [32, 39],
+		yellow: [33, 39],
+		blue: [34, 39],
+		magenta: [35, 39],
+		cyan: [36, 39],
+		white: [37, 39],
+
+		// Bright color
+		blackBright: [90, 39],
+		gray: [90, 39], // Alias of `blackBright`
+		grey: [90, 39], // Alias of `blackBright`
+		redBright: [91, 39],
+		greenBright: [92, 39],
+		yellowBright: [93, 39],
+		blueBright: [94, 39],
+		magentaBright: [95, 39],
+		cyanBright: [96, 39],
+		whiteBright: [97, 39],
+	},
+	bgColor: {
+		bgBlack: [40, 49],
+		bgRed: [41, 49],
+		bgGreen: [42, 49],
+		bgYellow: [43, 49],
+		bgBlue: [44, 49],
+		bgMagenta: [45, 49],
+		bgCyan: [46, 49],
+		bgWhite: [47, 49],
+
+		// Bright color
+		bgBlackBright: [100, 49],
+		bgGray: [100, 49], // Alias of `bgBlackBright`
+		bgGrey: [100, 49], // Alias of `bgBlackBright`
+		bgRedBright: [101, 49],
+		bgGreenBright: [102, 49],
+		bgYellowBright: [103, 49],
+		bgBlueBright: [104, 49],
+		bgMagentaBright: [105, 49],
+		bgCyanBright: [106, 49],
+		bgWhiteBright: [107, 49],
+	},
+};
+
+export const modifierNames = Object.keys(styles.modifier);
+export const foregroundColorNames = Object.keys(styles.color);
+export const backgroundColorNames = Object.keys(styles.bgColor);
+export const colorNames = [...foregroundColorNames, ...backgroundColorNames];
+
+function assembleStyles() {
+	const codes = new Map();
+
+	for (const [groupName, group] of Object.entries(styles)) {
+		for (const [styleName, style] of Object.entries(group)) {
+			styles[styleName] = {
+				open: `\u001B[${style[0]}m`,
+				close: `\u001B[${style[1]}m`,
+			};
+
+			group[styleName] = styles[styleName];
+
+			codes.set(style[0], style[1]);
+		}
+
+		Object.defineProperty(styles, groupName, {
+			value: group,
+			enumerable: false,
+		});
+	}
+
+	Object.defineProperty(styles, 'codes', {
+		value: codes,
+		enumerable: false,
+	});
+
+	styles.color.close = '\u001B[39m';
+	styles.bgColor.close = '\u001B[49m';
+
+	styles.color.ansi = wrapAnsi16();
+	styles.color.ansi256 = wrapAnsi256();
+	styles.color.ansi16m = wrapAnsi16m();
+	styles.bgColor.ansi = wrapAnsi16(ANSI_BACKGROUND_OFFSET);
+	styles.bgColor.ansi256 = wrapAnsi256(ANSI_BACKGROUND_OFFSET);
+	styles.bgColor.ansi16m = wrapAnsi16m(ANSI_BACKGROUND_OFFSET);
+
+	// From https://github.com/Qix-/color-convert/blob/3f0e0d4e92e235796ccb17f6e85c72094a651f49/conversions.js
+	Object.defineProperties(styles, {
+		rgbToAnsi256: {
+			value(red, green, blue) {
+				// We use the extended greyscale palette here, with the exception of
+				// black and white. normal palette only has 4 greyscale shades.
+				if (red === green && green === blue) {
+					if (red < 8) {
+						return 16;
+					}
+
+					if (red > 248) {
+						return 231;
+					}
+
+					return Math.round(((red - 8) / 247) * 24) + 232;
+				}
+
+				return 16
+					+ (36 * Math.round(red / 255 * 5))
+					+ (6 * Math.round(green / 255 * 5))
+					+ Math.round(blue / 255 * 5);
+			},
+			enumerable: false,
+		},
+		hexToRgb: {
+			value(hex) {
+				const matches = /[a-f\d]{6}|[a-f\d]{3}/i.exec(hex.toString(16));
+				if (!matches) {
+					return [0, 0, 0];
+				}
+
+				let [colorString] = matches;
+
+				if (colorString.length === 3) {
+					colorString = [...colorString].map(character => character + character).join('');
+				}
+
+				const integer = Number.parseInt(colorString, 16);
+
+				return [
+					/* eslint-disable no-bitwise */
+					(integer >> 16) & 0xFF,
+					(integer >> 8) & 0xFF,
+					integer & 0xFF,
+					/* eslint-enable no-bitwise */
+				];
+			},
+			enumerable: false,
+		},
+		hexToAnsi256: {
+			value: hex => styles.rgbToAnsi256(...styles.hexToRgb(hex)),
+			enumerable: false,
+		},
+		ansi256ToAnsi: {
+			value(code) {
+				if (code < 8) {
+					return 30 + code;
+				}
+
+				if (code < 16) {
+					return 90 + (code - 8);
+				}
+
+				let red;
+				let green;
+				let blue;
+
+				if (code >= 232) {
+					red = (((code - 232) * 10) + 8) / 255;
+					green = red;
+					blue = red;
+				} else {
+					code -= 16;
+
+					const remainder = code % 36;
+
+					red = Math.floor(code / 36) / 5;
+					green = Math.floor(remainder / 6) / 5;
+					blue = (remainder % 6) / 5;
+				}
+
+				const value = Math.max(red, green, blue) * 2;
+
+				if (value === 0) {
+					return 30;
+				}
+
+				// eslint-disable-next-line no-bitwise
+				let result = 30 + ((Math.round(blue) << 2) | (Math.round(green) << 1) | Math.round(red));
+
+				if (value === 2) {
+					result += 60;
+				}
+
+				return result;
+			},
+			enumerable: false,
+		},
+		rgbToAnsi: {
+			value: (red, green, blue) => styles.ansi256ToAnsi(styles.rgbToAnsi256(red, green, blue)),
+			enumerable: false,
+		},
+		hexToAnsi: {
+			value: hex => styles.ansi256ToAnsi(styles.hexToAnsi256(hex)),
+			enumerable: false,
+		},
+	});
+
+	return styles;
+}
+
+const ansiStyles = assembleStyles();
+
+export default ansiStyles;

--- a/testrepo/node_workspaces/node_modules/chalk/source/vendor/supports-color/browser.d.ts
+++ b/testrepo/node_workspaces/node_modules/chalk/source/vendor/supports-color/browser.d.ts
@@ -1,0 +1,1 @@
+export {default} from './index.js';

--- a/testrepo/node_workspaces/node_modules/chalk/source/vendor/supports-color/browser.js
+++ b/testrepo/node_workspaces/node_modules/chalk/source/vendor/supports-color/browser.js
@@ -1,0 +1,30 @@
+/* eslint-env browser */
+
+const level = (() => {
+	if (navigator.userAgentData) {
+		const brand = navigator.userAgentData.brands.find(({brand}) => brand === 'Chromium');
+		if (brand && brand.version > 93) {
+			return 3;
+		}
+	}
+
+	if (/\b(Chrome|Chromium)\//.test(navigator.userAgent)) {
+		return 1;
+	}
+
+	return 0;
+})();
+
+const colorSupport = level !== 0 && {
+	level,
+	hasBasic: true,
+	has256: level >= 2,
+	has16m: level >= 3,
+};
+
+const supportsColor = {
+	stdout: colorSupport,
+	stderr: colorSupport,
+};
+
+export default supportsColor;

--- a/testrepo/node_workspaces/node_modules/chalk/source/vendor/supports-color/index.d.ts
+++ b/testrepo/node_workspaces/node_modules/chalk/source/vendor/supports-color/index.d.ts
@@ -1,0 +1,55 @@
+import type {WriteStream} from 'node:tty';
+
+export type Options = {
+	/**
+	Whether `process.argv` should be sniffed for `--color` and `--no-color` flags.
+
+	@default true
+	*/
+	readonly sniffFlags?: boolean;
+};
+
+/**
+Levels:
+- `0` - All colors disabled.
+- `1` - Basic 16 colors support.
+- `2` - ANSI 256 colors support.
+- `3` - Truecolor 16 million colors support.
+*/
+export type ColorSupportLevel = 0 | 1 | 2 | 3;
+
+/**
+Detect whether the terminal supports color.
+*/
+export type ColorSupport = {
+	/**
+	The color level.
+	*/
+	level: ColorSupportLevel;
+
+	/**
+	Whether basic 16 colors are supported.
+	*/
+	hasBasic: boolean;
+
+	/**
+	Whether ANSI 256 colors are supported.
+	*/
+	has256: boolean;
+
+	/**
+	Whether Truecolor 16 million colors are supported.
+	*/
+	has16m: boolean;
+};
+
+export type ColorInfo = ColorSupport | false;
+
+export function createSupportsColor(stream?: WriteStream, options?: Options): ColorInfo;
+
+declare const supportsColor: {
+	stdout: ColorInfo;
+	stderr: ColorInfo;
+};
+
+export default supportsColor;

--- a/testrepo/node_workspaces/node_modules/chalk/source/vendor/supports-color/index.js
+++ b/testrepo/node_workspaces/node_modules/chalk/source/vendor/supports-color/index.js
@@ -1,0 +1,181 @@
+import process from 'node:process';
+import os from 'node:os';
+import tty from 'node:tty';
+
+// From: https://github.com/sindresorhus/has-flag/blob/main/index.js
+function hasFlag(flag, argv = globalThis.Deno ? globalThis.Deno.args : process.argv) {
+	const prefix = flag.startsWith('-') ? '' : (flag.length === 1 ? '-' : '--');
+	const position = argv.indexOf(prefix + flag);
+	const terminatorPosition = argv.indexOf('--');
+	return position !== -1 && (terminatorPosition === -1 || position < terminatorPosition);
+}
+
+const {env} = process;
+
+let flagForceColor;
+if (
+	hasFlag('no-color')
+	|| hasFlag('no-colors')
+	|| hasFlag('color=false')
+	|| hasFlag('color=never')
+) {
+	flagForceColor = 0;
+} else if (
+	hasFlag('color')
+	|| hasFlag('colors')
+	|| hasFlag('color=true')
+	|| hasFlag('color=always')
+) {
+	flagForceColor = 1;
+}
+
+function envForceColor() {
+	if ('FORCE_COLOR' in env) {
+		if (env.FORCE_COLOR === 'true') {
+			return 1;
+		}
+
+		if (env.FORCE_COLOR === 'false') {
+			return 0;
+		}
+
+		return env.FORCE_COLOR.length === 0 ? 1 : Math.min(Number.parseInt(env.FORCE_COLOR, 10), 3);
+	}
+}
+
+function translateLevel(level) {
+	if (level === 0) {
+		return false;
+	}
+
+	return {
+		level,
+		hasBasic: true,
+		has256: level >= 2,
+		has16m: level >= 3,
+	};
+}
+
+function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
+	const noFlagForceColor = envForceColor();
+	if (noFlagForceColor !== undefined) {
+		flagForceColor = noFlagForceColor;
+	}
+
+	const forceColor = sniffFlags ? flagForceColor : noFlagForceColor;
+
+	if (forceColor === 0) {
+		return 0;
+	}
+
+	if (sniffFlags) {
+		if (hasFlag('color=16m')
+			|| hasFlag('color=full')
+			|| hasFlag('color=truecolor')) {
+			return 3;
+		}
+
+		if (hasFlag('color=256')) {
+			return 2;
+		}
+	}
+
+	// Check for Azure DevOps pipelines.
+	// Has to be above the `!streamIsTTY` check.
+	if ('TF_BUILD' in env && 'AGENT_NAME' in env) {
+		return 1;
+	}
+
+	if (haveStream && !streamIsTTY && forceColor === undefined) {
+		return 0;
+	}
+
+	const min = forceColor || 0;
+
+	if (env.TERM === 'dumb') {
+		return min;
+	}
+
+	if (process.platform === 'win32') {
+		// Windows 10 build 10586 is the first Windows release that supports 256 colors.
+		// Windows 10 build 14931 is the first release that supports 16m/TrueColor.
+		const osRelease = os.release().split('.');
+		if (
+			Number(osRelease[0]) >= 10
+			&& Number(osRelease[2]) >= 10_586
+		) {
+			return Number(osRelease[2]) >= 14_931 ? 3 : 2;
+		}
+
+		return 1;
+	}
+
+	if ('CI' in env) {
+		if ('GITHUB_ACTIONS' in env) {
+			return 3;
+		}
+
+		if (['TRAVIS', 'CIRCLECI', 'APPVEYOR', 'GITLAB_CI', 'BUILDKITE', 'DRONE'].some(sign => sign in env) || env.CI_NAME === 'codeship') {
+			return 1;
+		}
+
+		return min;
+	}
+
+	if ('TEAMCITY_VERSION' in env) {
+		return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? 1 : 0;
+	}
+
+	if (env.COLORTERM === 'truecolor') {
+		return 3;
+	}
+
+	if (env.TERM === 'xterm-kitty') {
+		return 3;
+	}
+
+	if ('TERM_PROGRAM' in env) {
+		const version = Number.parseInt((env.TERM_PROGRAM_VERSION || '').split('.')[0], 10);
+
+		switch (env.TERM_PROGRAM) {
+			case 'iTerm.app': {
+				return version >= 3 ? 3 : 2;
+			}
+
+			case 'Apple_Terminal': {
+				return 2;
+			}
+			// No default
+		}
+	}
+
+	if (/-256(color)?$/i.test(env.TERM)) {
+		return 2;
+	}
+
+	if (/^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/i.test(env.TERM)) {
+		return 1;
+	}
+
+	if ('COLORTERM' in env) {
+		return 1;
+	}
+
+	return min;
+}
+
+export function createSupportsColor(stream, options = {}) {
+	const level = _supportsColor(stream, {
+		streamIsTTY: stream && stream.isTTY,
+		...options,
+	});
+
+	return translateLevel(level);
+}
+
+const supportsColor = {
+	stdout: createSupportsColor({isTTY: tty.isatty(1)}),
+	stderr: createSupportsColor({isTTY: tty.isatty(2)}),
+};
+
+export default supportsColor;

--- a/testrepo/node_workspaces/node_modules/workspace-a
+++ b/testrepo/node_workspaces/node_modules/workspace-a
@@ -1,0 +1,1 @@
+../workspace-a

--- a/testrepo/node_workspaces/node_modules/workspace-b
+++ b/testrepo/node_workspaces/node_modules/workspace-b
@@ -1,0 +1,1 @@
+../workspace-b

--- a/testrepo/node_workspaces/package-lock.json
+++ b/testrepo/node_workspaces/package-lock.json
@@ -1,0 +1,77 @@
+{
+  "name": "node_workspaces",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node_workspaces",
+      "version": "1.0.0",
+      "license": "ISC",
+      "workspaces": [
+        "workspace-a",
+        "workspace-b"
+      ],
+      "dependencies": {
+        "chalk": "^5.2.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.2.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      }
+    },
+    "node_modules/workspace-a": {
+      "resolved": "workspace-a",
+      "link": true
+    },
+    "node_modules/workspace-b": {
+      "resolved": "workspace-b",
+      "link": true
+    },
+    "workspace-a": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      }
+    },
+    "workspace-b": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {}
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="
+    },
+    "chalk": {
+      "version": "5.2.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
+    },
+    "workspace-a": {
+      "version": "file:workspace-a",
+      "requires": {
+        "abbrev": "^2.0.0"
+      }
+    },
+    "workspace-b": {
+      "version": "file:workspace-b"
+    }
+  }
+}

--- a/testrepo/node_workspaces/package.json
+++ b/testrepo/node_workspaces/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "node_workspaces",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "workspaces": [
+    "workspace-a",
+    "workspace-b"
+  ],
+  "dependencies": {
+    "chalk": "^5.2.0"
+  }
+}

--- a/testrepo/node_workspaces/workspace-a/package.json
+++ b/testrepo/node_workspaces/workspace-a/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "workspace-a",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "abbrev": "^2.0.0"
+  }
+}

--- a/testrepo/node_workspaces/workspace-b/package.json
+++ b/testrepo/node_workspaces/workspace-b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "workspace-b",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
This provides a workaround for snyk-bulk to handle npm workspaces. The problem is that the Snyk CLI looks for either a package-lock.json file or an npm_modules directory in the folder being scanned and errors out if they're not there.

We can get around it by putting an empty npm_modules folder in each of the workspaces. This allows the scan to go ahead and the empty folders don't affect the results because the `npm list` command used by snyk can still figure out which dependencies are used by the workspace.