### PR TITLE
Feat/prep.sh fix

### DIFF
--- a/entrypoints/dotnet.sh
+++ b/entrypoints/dotnet.sh
@@ -30,19 +30,18 @@ snyk_nuget(){
   elif [[ -f "project.json" ]]; then
 
     (dotnet restore ) &>> "${SNYK_LOG_FILE}"
-    run_snyk "${manifest}" "nuget" "${prefix}/${manifest}"
 
   elif [[ -f "packages.config" ]]; then
 
     (dotnet restore ) &>> "${SNYK_LOG_FILE}"
-    run_snyk "${manifest}" "nuget" "${prefix}/${manifest}"
 
   elif  [[ -f "project.assets.json" ]]; then
 
     (dotnet restore ) &>> "${SNYK_LOG_FILE}"
-    run_snyk "${manifest}" "nuget" "${prefix}/${manifest}"
 
   fi
+
+  run_snyk "${manifest}" "nuget" "${prefix}/${manifest}"
 
   cd "${BASE}" || exit
 }
@@ -65,10 +64,11 @@ snyk_paket(){
   else
     if ! [ -f "paket.lock" ]; then
       (dotnet paket install) &>> "${SNYK_LOG_FILE}"
+    fi
   fi
 
   run_snyk "${manifest}" "nuget" "${prefix}/${manifest}"
-  fi
+  
 
   cd "${BASE}" || exit
 }

--- a/entrypoints/node.sh
+++ b/entrypoints/node.sh
@@ -27,9 +27,9 @@ snyk_yarnfile() {
   
   if [ -f ".snyk.d/prep.sh" ]; then
     use_custom
-  else
-    run_snyk "${manifest}" "yarn" "${prefix}/${manifest}"
   fi
+
+  run_snyk "${manifest}" "yarn" "${prefix}/${manifest}"
 
   cd "${BASE}" || exit
 }
@@ -50,7 +50,9 @@ snyk_packagefile() {
   
   if [ -f ".snyk.d/prep.sh" ]; then
     use_custom
-  elif [ -f "package-lock.json" ] && [ ! -e "yarn.lock" ]; then
+  fi
+
+  if [ -f "package-lock.json" ] && [ ! -e "yarn.lock" ]; then
   
     run_snyk "package-lock.json" "npm" "${prefix}/${manifest}"
   

--- a/entrypoints/python.sh
+++ b/entrypoints/python.sh
@@ -103,17 +103,19 @@ snyk_reqfile(){
   prefix=${project_path#"${SNYK_TARGET}"}
 
   cd "${project_path}" || exit
+  if ! [[ -d 'snyktmp' ]]; then
+    virtualenv --quiet snyktmp 
+  fi
+  source snyktmp/bin/activate
+
   if [ -f ".snyk.d/prep.sh" ]; then
     use_custom
   else
-    if ! [[ -d 'snyktmp' ]]; then
-      virtualenv --quiet snyktmp 
-    fi
-    source snyktmp/bin/activate
     pip install --quiet -r requirements.txt
-    run_snyk "${manifest}" "pip" "${prefix}/${manifest}"
-    deactivate
   fi
+
+  run_snyk "${manifest}" "pip" "${prefix}/${manifest}"
+  deactivate
   
   cd "${BASE}" || exit
 }
@@ -130,17 +132,19 @@ snyk_setupfile(){
   prefix=${project_path#"${SNYK_TARGET}"}
 
   cd "${project_path}" || exit
+  if ! [[ -d 'snyktmp' ]]; then
+    virtualenv --quiet snyktmp
+  fi
+  source snyktmp/bin/activate
+
   if [ -f ".snyk.d/prep.sh" ]; then
     use_custom
   elif ! [[ -f "requirements.txt" ]]; then
-    if ! [[ -d 'snyktmp' ]]; then
-      virtualenv --quiet snyktmp
-    fi
-    source snyktmp/bin/activate
     pip install --quiet -U -e ./ && pip --quiet freeze > requirements.txt
-    run_snyk "${manifest}" "pip" "${prefix}/${manifest}"
-    deactivate
   fi
+
+  run_snyk "${manifest}" "pip" "${prefix}/${manifest}"
+  deactivate
   
   cd "${BASE}" || exit
 }

--- a/entrypoints/ruby.sh
+++ b/entrypoints/ruby.sh
@@ -25,15 +25,9 @@ snyk_gemfile() {
 
   cd "${project_path}" || exit
   
-  if use_custom; then
-    local timestamp
-    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    ( echo "${timestamp}|  Custom Script was run for : ${project_path}" >> "${SNYK_LOG_FILE}" ) 2>&1 | tee -a "${SNYK_LOG_FILE}"
-  
-  elif [ -f "Gemfile.lock" ]; then
-  
-    run_snyk "Gemfile.lock" "rubygems" "${prefix}/${manifest}" 2> /dev/null
-  
+  if [ -f ".snyk.d/prep.sh" ]; then
+    use_custom
+    
   elif [ ! -f "Gemfile.lock" ]; then
 
     timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -59,9 +53,10 @@ snyk_gemfile() {
       fi
     ) 2>&1 | tee -a "${SNYK_LOG_FILE}"
 
-    run_snyk "Gemfile.lock" "rubygems" "${prefix}/${manifest}"    
 
   fi
+
+  run_snyk "Gemfile.lock" "rubygems" "${prefix}/${manifest}" 
   
   cd "${BASE}" || exit
 }


### PR DESCRIPTION
- Changes to how .Net, Node, Python, and Ruby are run
- Calls run_snyk after all setup is complete. This Ensures that if a prep.sh file is present, run_snyk is still called
- The call to use_custom just runs the prep.sh file (plus logs a comment that the prep.sh is running)

For Ruby
- removes extraneous code that is included in the call to use_custom


