### PR TITLE
use different yarn workspaces command when running yarn 1.x

### DIFF
--- a/entrypoints/node.sh
+++ b/entrypoints/node.sh
@@ -78,20 +78,22 @@ prep_for_yarn_workspaces() {
 
   cd "${project_path}" || exit
   #readarray -t yarn_workspaces_result < <(set -o pipefail; yarn workspaces list --json | tail -n+2 | cut -f4 -d\")
-  yarn_workspaces_result=$(yarn workspaces list --json)
-  yarn_workspaces_return_code=$?
-
-  if [[ $yarn_workspaces_return_code -gt 0 ]]; then
-    # probably not a yarn workspace project
-    # let's go back to the root directory
-    break
-  else # this is yarn workspace project
-    #results will be relative paths
+  # yarn workspaces list is only available in yarn 2+. Otherwise use yarn workspaces info
+  if [[ $(yarn -v | cut -d. -f1) -gt 1 ]]; then
+    yarn_workspaces_result=$(yarn workspaces list --json)
+    yarn_workspaces_return_code=$?
+    if [[ $yarn_workspaces_return_code -gt 0 ]]; then return $yarn_workspaces_return_code; fi
     readarray -t yarn_workspaces_result < <(echo "${yarn_workspaces_result}" | tail -n+2 | cut -f4 -d\")
-    for packagedir in "${yarn_workspaces_result[@]}"; do
-      ln $manifest $packagedir/$manifest
-    done
+  else
+    yarn_workspaces_result=$(yarn workspaces info --json)
+    yarn_workspaces_return_code=$?
+    if [[ $yarn_workspaces_return_code -gt 0 ]]; then return $yarn_workspaces_return_code; fi
+    readarray -t yarn_workspaces_result < <(echo "${yarn_workspaces_result}" | tail -n +2 | head -n -1 | jq -r 'to_entries | .[] | .value.location')
   fi
+
+  for packagedir in "${yarn_workspaces_result[@]}"; do
+    ln $manifest $packagedir/$manifest
+  done
 }
 
 node::main() {


### PR DESCRIPTION
This handles the case where the repository is bundled with yarn 1.x but is also using yarn workspaces.

Yarn 1 does not support the `yarn workspaces list` command but does have  a `yarn workspaces info --json` that can provide the same info in a different format. Now prep_for_yarn_workspaces will detect what version is being used and will use the correct command to get the list of workspaces.