### PR TITLE
Minor fixes for npm errors

### DIFF
--- a/entrypoints/node.sh
+++ b/entrypoints/node.sh
@@ -52,20 +52,20 @@ snyk_packagefile() {
     use_custom
   fi
 
-  if [ -f "package-lock.json" ] && [ ! -e "yarn.lock" ]; then
+  if [ -e "package-lock.json" ] && [ ! -e "yarn.lock" ]; then
   
     run_snyk "package-lock.json" "npm" "${prefix}/${manifest}"
   
-  elif [ ! -f "package-lock.json" ] && [ ! -e "yarn.lock" ] && [ -d "node_modules" ]; then
+  elif [ ! -e "package-lock.json" ] && [ ! -e "yarn.lock" ] && [ -d "node_modules" ]; then
 
     run_snyk "${manifest}" "npm" "${prefix}/${manifest}"
 
-  elif [ ! -f "package-lock.json" ] && [ ! -e "yarn.lock" ] && [ ! -d "node_modules" ]; then
+  elif [ ! -e "package-lock.json" ] && [ ! -e "yarn.lock" ] && [ ! -d "node_modules" ]; then
 
     timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
     ( echo "${timestamp}| npm install for ${prefix}/${manifest}: $(npm install --silent --no-audit)" >> "${SNYK_LOG_FILE}" ) 2>&1 | tee -a "${SNYK_LOG_FILE}"
 
-    run_snyk "package-lock.json" "npm" "${prefix}/${manifest}"    
+    run_snyk "${manifest}" "npm" "${prefix}/${manifest}"    
 
   fi
   


### PR DESCRIPTION
Changes:
- checking for the existence of a `package-lock.json` file will recognize symlinks. (The npm workaround I have creates lockfile symlinks)
- In the case where snyk runs `npm install` will use the original manifest, `package.json` instead of `package-lock.json`. I observed several cases where running `npm install` will not generate a lockfile. And so the scan fails even when it shouldn't. 

Note:
Determining dependencies from running `npm install` rather than parsing a lockfile can result in incorrect dependencies being identified. E.g. if a package file says `package: >5.0.0`  and the latest version is 5.6.0. Even if the developer used version 5.4.0, npm would still install 5.6.0 and so Snyk would record the dependency as 5.6.0. 
At least this behavior won't result in a lot of FPs, and there aren't any other options if there is no lockfile.