### PR TITLE
Sort manifests before scanning

### DIFF
--- a/entrypoints/dotnet.sh
+++ b/entrypoints/dotnet.sh
@@ -90,10 +90,10 @@ dotnet::main() {
   local paketfiles
 
   set -o noglob
-  readarray -t projectfiles < <(find "${SNYK_TARGET}" -type f -name "project.json" $SNYK_IGNORES )
-  readarray -t packagesfiles < <(find "${SNYK_TARGET}" -type f -name "packages.config" $SNYK_IGNORES )
-  readarray -t assetsfiles < <(find "${SNYK_TARGET}" -type f -name "project.assets.json" $SNYK_IGNORES )
-  readarray -t paketfiles < <(find "${SNYK_TARGET}" -type f -name "paket.dependencies" $SNYK_IGNORES )
+  readarray -t projectfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "project.json" $SNYK_IGNORES)")
+  readarray -t packagesfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "packages.config" $SNYK_IGNORES)")
+  readarray -t assetsfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "project.assets.json" $SNYK_IGNORES)")
+  readarray -t paketfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "paket.dependencies" $SNYK_IGNORES)")
   set +o noglob
 
   for projectfile in "${projectfiles[@]}"; do

--- a/entrypoints/go.sh
+++ b/entrypoints/go.sh
@@ -80,8 +80,8 @@ go::main() {
 #  local godepfile
 
   set -o noglob
-  readarray -t gomodfile < <(find "${SNYK_TARGET}" -type f -name "go.mod" $SNYK_IGNORES )
-#  readarray -t godepfile < <(find "${SNYK_TARGET}" -type f -name "Gopkg.lock" $SNYK_IGNORES )
+  readarray -t gomodfile < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "go.mod" $SNYK_IGNORES)")
+#  readarray -t godepfile < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "Gopkg.lock" $SNYK_IGNORES)")
   set +o noglob
 
   for gomodfile in "${gomodfile[@]}"; do

--- a/entrypoints/gradle.sh
+++ b/entrypoints/gradle.sh
@@ -53,8 +53,8 @@ gradle::main() {
   local gradlekotlinfiles
 
   set -o noglob
-  readarray -t gradlegroovyfiles < <(find "${SNYK_TARGET}" -type f -name "build.gradle" $SNYK_IGNORES )
-  readarray -t gradlekotlinfiles < <(find "${SNYK_TARGET}" -type f -name "build.gradle.kts" $SNYK_IGNORES )
+  readarray -t gradlegroovyfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "build.gradle" $SNYK_IGNORES)")
+  readarray -t gradlekotlinfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "build.gradle.kts" $SNYK_IGNORES)")
   set +o noglob
 
   for gradlefile in "${gradlegroovyfiles[@]}"; do

--- a/entrypoints/gradle_groovy.sh
+++ b/entrypoints/gradle_groovy.sh
@@ -53,8 +53,8 @@ gradle::main() {
   local gradlekotlinfiles
 
   set -o noglob
-  readarray -t gradlegroovyfiles < <(find "${SNYK_TARGET}" -type f -name "build.gradle" $SNYK_IGNORES )
-#  readarray -t gradlekotlinfiles < <(find "${SNYK_TARGET}" -type f -name "build.gradle.kts" $SNYK_IGNORES )
+  readarray -t gradlegroovyfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "build.gradle" $SNYK_IGNORES)")
+#  readarray -t gradlekotlinfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "build.gradle.kts" $SNYK_IGNORES)")
   set +o noglob
 
   for gradlefile in "${gradlegroovyfiles[@]}"; do

--- a/entrypoints/gradle_kotlin.sh
+++ b/entrypoints/gradle_kotlin.sh
@@ -53,8 +53,8 @@ gradle::main() {
   local gradlekotlinfiles
 
   set -o noglob
-#  readarray -t gradlegroovyfiles < <(find "${SNYK_TARGET}" -type f -name "build.gradle" $SNYK_IGNORES )
-  readarray -t gradlekotlinfiles < <(find "${SNYK_TARGET}" -type f -name "build.gradle.kts" $SNYK_IGNORES )
+#  readarray -t gradlegroovyfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "build.gradle" $SNYK_IGNORES)")
+  readarray -t gradlekotlinfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "build.gradle.kts" $SNYK_IGNORES)")
   set +o noglob
 
 #  for gradlefile in "${gradlegroovyfiles[@]}"; do

--- a/entrypoints/maven.sh
+++ b/entrypoints/maven.sh
@@ -53,7 +53,7 @@ maven::main() {
   local pomfiles
 
   set -o noglob
-  readarray -t pomfiles < <(find "${SNYK_TARGET}" -type f -name "pom.xml" $SNYK_IGNORES )
+  readarray -t pomfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "pom.xml" $SNYK_IGNORES)")
   set +o noglob
 
   # Run a maven install in the root of the directory

--- a/entrypoints/node.sh
+++ b/entrypoints/node.sh
@@ -115,8 +115,8 @@ node::main() {
   local targetdir=$(pwd)
 
   set -o noglob
-  readarray -t yarnfiles < <(find "${SNYK_TARGET}" -type f -name "yarn.lock" $SNYK_IGNORES )
-  readarray -t packages < <(find "${SNYK_TARGET}" -type f -name "package.json" $SNYK_IGNORES )
+  readarray -t yarnfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "yarn.lock" $SNYK_IGNORES)")
+  readarray -t packages < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "package.json" $SNYK_IGNORES )")
   set +o noglob
 
   # check if any yarn projects are workspaces and prep with hard links
@@ -129,7 +129,7 @@ node::main() {
 
   # check for yarn.lock files again after hard links created
   set -o noglob
-  readarray -t yarnfiles < <(find "${SNYK_TARGET}" -type f -name "yarn.lock" $SNYK_IGNORES )
+  readarray -t yarnfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "yarn.lock" $SNYK_IGNORES)")
   set +o noglob
   
   for yarnfile in "${yarnfiles[@]}"; do

--- a/entrypoints/python.sh
+++ b/entrypoints/python.sh
@@ -169,10 +169,10 @@ python::main() {
   local setupfiles
 
   set -o noglob
-  readarray -t pipfiles < <(find "${SNYK_TARGET}" -type f -name "Pipfile" $SNYK_IGNORES )
-  readarray -t poetryfiles < <(find "${SNYK_TARGET}" -type f -name "pyproject.toml" $SNYK_IGNORES )
-  readarray -t reqfiles < <(find "${SNYK_TARGET}" -type f -name "requirements.txt" $SNYK_IGNORES )
-  readarray -t setupfiles < <(find "${SNYK_TARGET}" -type f -name "setup.py" $SNYK_IGNORES )
+  readarray -t pipfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "Pipfile" $SNYK_IGNORES)")
+  readarray -t poetryfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "pyproject.toml" $SNYK_IGNORES)")
+  readarray -t reqfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "requirements.txt" $SNYK_IGNORES)")
+  readarray -t setupfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "setup.py" $SNYK_IGNORES)")
   set +o noglob
   
   for pipfile in "${pipfiles[@]}"; do

--- a/entrypoints/ruby.sh
+++ b/entrypoints/ruby.sh
@@ -78,7 +78,7 @@ ruby::main() {
   local gemfiles
 
   set -o noglob
-  readarray -t gemfiles < <(find "${SNYK_TARGET}" -type f -name "Gemfile" $SNYK_IGNORES )
+  readarray -t gemfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "Gemfile" $SNYK_IGNORES)")
   set +o noglob
 
 

--- a/entrypoints/util.sh
+++ b/entrypoints/util.sh
@@ -211,3 +211,10 @@ use_custom(){
     return 1
   fi
 }
+
+sort_manifests() {
+  # This function sorts the input by depth in a file structure
+  # For many projects, we want to scan the root manifest first.
+  # Sorting ensures we do that
+  echo "$1" | awk -F"/" '{print NF, $0}' | sort -n -k1 | cut -d' ' -f2-
+}


### PR DESCRIPTION
Changes:
- Added a function to sort the manifest files by depth, e.g. how deep they are in the file hierarchy. This will ensure that any manifest files in the root of the repo will get scanned first. Depth is determined by the number of "/" in the file path.
- Applied this function to all of the entry points

The goal here was to make sure that any .snyk.d/prep.sh scripts in the root of the repo would get run first. Sorting all the files to scan is not necessary, but it's a solution that made sense to me. Happy to take feedback on it!