### PR TITLE
Fix bug causing snyk to scan manifests that don't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ docker build -t snyk-bulk:python3 -f Dockerfile-python .
 snyk scan all python3 projects
 
 ```
-docker run -it --rm --env SNYK_TOKEN --env CI=1 \ -v $(PWD):/project \
-  snyk-bulk:python3 \
-  --test --target /project --json-std-out
+docker run -it --rm --env SNYK_TOKEN --env CI=1 -v $(PWD):/project snyk-bulk:python3 --test --target /project --json-std-out
 ```
 
 ## Entrypoint options

--- a/entrypoints/util.sh
+++ b/entrypoints/util.sh
@@ -214,7 +214,10 @@ use_custom(){
 
 sort_manifests() {
   # This function sorts the input by depth in a file structure
-  # For many projects, we want to scan the root manifest first.
-  # Sorting ensures we do that
-  echo "$1" | awk -F"/" '{print NF, $0}' | sort -n -k1 | cut -d' ' -f2-
+  if [[ -n "$1" ]]; then
+    # if the input is not empty, count the number of "/" in each string of the array
+    # then create a tuple `{depth, path}` and sort the array by depth
+    # finally, remove the depth from each entry in the array
+    echo "$1" | awk -F"/" '{print NF, $0}' | sort -n -k1 | cut -d' ' -f2-
+  fi
 }


### PR DESCRIPTION
- added a check to the `sort_manifests` function that will return no output if the input is empty
- added an explanation for the convoluted sorting function
- edited readme for the docker run command


Tested this with node on an npm repo. Confirmed that there was no list of "yarnfiles" returned or scanned
