### PR TITLE
remove extra scan and add flag to maven builds

### DIFF
--- a/entrypoints/maven.sh
+++ b/entrypoints/maven.sh
@@ -30,7 +30,7 @@ snyk_pomfile(){
   else
     # something there
     
-    (mvn install -DskipTests -Denforcer.fail=false -Dscope=runtime --fail-never) &>> "${SNYK_LOG_FILE}"
+    (mvn install -DskipTests -Denforcer.fail=false -Ddocker.skip=true -Dscope=runtime --fail-never) &>> "${SNYK_LOG_FILE}"
 
   fi
 
@@ -55,14 +55,6 @@ maven::main() {
   set -o noglob
   readarray -t pomfiles < <(sort_manifests "$(find "${SNYK_TARGET}" -type f -name "pom.xml" $SNYK_IGNORES)")
   set +o noglob
-
-  # Run a maven install in the root of the directory
-  # This helps when scanning projects that use modules
-
-  if [[ -f "$SNYK_TARGET/pom.xml" ]]; then
-      mvn install --file="$SNYK_TARGET/pom.xml" -DskipTests -Denforcer.fail=false -Dscope=runtime --fail-never
-  fi
-
 
   for pomfile in "${pomfiles[@]}"; do
     snyk_pomfile "${pomfile}"


### PR DESCRIPTION

For maven scans, we were running a mvn install in the root director first in case there were submodules it needed to build.

Now that we're running the builds in order of depth, this is no longer needed and needs to be removed in case someone needs to run a prep.sh prior to the first build.

I've also added -Ddocker.skip=true to the flags passed to maven. We don't provide docker in the build container (that would be tricky and probably not a good idea) so these steps are currently just failing.
