### PR TITLE
Retry certain API errors from the snyk monitor and snyk test commands

### DIFF
--- a/entrypoints/cmdline.sh
+++ b/entrypoints/cmdline.sh
@@ -69,6 +69,10 @@ function cmdline()
         shift
         declare -gx SNYK_SEVERITY="${1}"
         ;;
+      --max-retries)
+        shift
+        declare -gx API_MAX_RETRIES=${1}
+        ;;
       --)
         # everything after this we pass to snyk
         shift
@@ -111,6 +115,7 @@ function cmdline()
   declare -gx SNYK_JSON_STDOUT="${SNYK_JSON_STDOUT:=0}"
   declare -gx SNYK_TEST_COUNT="${SNYK_TEST_COUNT:=0}"
   declare -gxa SNYK_EXTRA_OPTIONS="${SNYK_EXTRA_OPTIONS:=()}"
+  declare -gx API_MAX_RETRIES="${API_MAX_RETRIES:=0}"
   
   if ! [[ -z $SNYK_TARGET ]] && [[ -d "${SNYK_TARGET}" ]]; then
     declare -gx SNYK_TARGET="${SNYK_TARGET}"
@@ -161,7 +166,7 @@ function cmdline()
 
 
   # shellcheck disable=SC2034
-  readonly SNYK_LOG_FILE SNYK_FAIL SNYK_SEVERITY SNYK_REMOTE_REPO_URL SNYK_MONITOR SNYK_TEST SNYK_BULK_DEBUG SNYK_TEST_COUNT SNYK_BASENAME SNYK_EXTRA_OPTIONS
+  readonly SNYK_LOG_FILE SNYK_FAIL SNYK_SEVERITY SNYK_REMOTE_REPO_URL SNYK_MONITOR SNYK_TEST SNYK_BULK_DEBUG SNYK_TEST_COUNT SNYK_BASENAME SNYK_EXTRA_OPTIONS API_MAX_RETRIES
 
   return 0
 }
@@ -186,7 +191,8 @@ cmdline::test() {
   echo "echo SNYK_EXTRA_OPTIONS=${SNYK_EXTRA_OPTIONS}"
   echo "echo JSON_TMP=${JSON_TMP}"
   echo "echo JSON_STDOUT=${JSON_STDOUT}"
+  echo "API_MAX_RETRIES = ${API_MAX_RETRIES}"
 
 }
 
-#cmdline::test "$@"
+# cmdline::test "$@"

--- a/entrypoints/util.sh
+++ b/entrypoints/util.sh
@@ -87,7 +87,7 @@ snyk_cmd(){
   project_json_pass="${SNYK_JSON_TMP}/${snyk_action}/pass/$(basename "${0}")-${project_clean}.json"
 
   attempt_num=0
-  while [$attempt_num -le $API_MAX_RETRIES]; do
+  while [ $attempt_num -le $API_MAX_RETRIES ]; do
   
     if [[ ${snyk_action} == "monitor" ]]; then
       snyk monitor --json \

--- a/entrypoints/util.sh
+++ b/entrypoints/util.sh
@@ -86,21 +86,34 @@ snyk_cmd(){
   project_json_fail="${SNYK_JSON_TMP}/${snyk_action}/fail/$(basename "${0}")-${project_clean}.json"
   project_json_pass="${SNYK_JSON_TMP}/${snyk_action}/pass/$(basename "${0}")-${project_clean}.json"
 
+  attempt_num=0
+  while [$attempt_num -le $API_MAX_RETRIES]; do
+  
+    if [[ ${snyk_action} == "monitor" ]]; then
+      snyk monitor --json \
+        "${SNYK_PARAMS[@]}" > "${project_json_fail}"
+      if [ "${PIPESTATUS[0]}" == '0' ]; then
+        mv "${project_json_fail}" "${project_json_pass}"
+        break
+      fi
 
-  if [[ ${snyk_action} == "monitor" ]]; then
-    snyk monitor --json \
-      "${SNYK_PARAMS[@]}" > "${project_json_fail}"
-    if [ "${PIPESTATUS[0]}" == '0' ]; then
-      mv "${project_json_fail}" "${project_json_pass}"
+    else
+      snyk test --json-file-output="${project_json_fail}" \
+        "${SNYK_PARAMS[@]}"
+      if [ $? == '0' ]; then
+        mv "${project_json_fail}" "${project_json_pass}"
+        break
+      fi
     fi
 
-  else
-    snyk test --json-file-output="${project_json_fail}" \
-      "${SNYK_PARAMS[@]}"
-    if [ $? == '0' ]; then
-      mv "${project_json_fail}" "${project_json_pass}"
+    if grep -q -e "Server returned unexpected error for the monitor request" -e "Connection timeout." "${project_json_fail}"; then
+      attempt_num=$(( attempt_num + 1 ))
+    else
+      # the errors are not retryable
+      break
     fi
-  fi
+  
+  done
 
   
 }


### PR DESCRIPTION
- cmdline.sh now recognizes a flag that enables retries and sets a maximum number of retries. By default there are 0 retries and the snyk monitor/test command will only be run once per manifest.
- added retry logic where snyk monitor/test are called. For each manifest that fails with a retry-able error, the command will be called again up to the maximum number