### PR TITLE
Log errors during npm install

### DIFF
--- a/entrypoints/node.sh
+++ b/entrypoints/node.sh
@@ -63,7 +63,7 @@ snyk_packagefile() {
   elif [ ! -e "package-lock.json" ] && [ ! -e "yarn.lock" ] && [ ! -d "node_modules" ]; then
 
     timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    ( echo "${timestamp}| npm install for ${prefix}/${manifest}: $(npm install --silent --no-audit)" >> "${SNYK_LOG_FILE}" ) 2>&1 | tee -a "${SNYK_LOG_FILE}"
+    ( echo "${timestamp}| npm install for ${prefix}/${manifest}: $(npm install --loglevel=error --no-audit)" >> "${SNYK_LOG_FILE}" ) 2>&1 | tee -a "${SNYK_LOG_FILE}"
 
     run_snyk "${manifest}" "npm" "${prefix}/${manifest}"    
 


### PR DESCRIPTION
It's hard to understand why an npm project is failing snyk scans, logging npm install errors should help