### PR TITLE
fix python manifest handling

### DIFF
--- a/entrypoints/python.sh
+++ b/entrypoints/python.sh
@@ -81,6 +81,9 @@ snyk_poetry(){
   if [ -f ".snyk.d/prep.sh" ]; then
     use_custom
   else
+    if ! grep -q -F "[tool.poetry]" pyproject.toml; then
+      return
+    fi
     if ! [ -f "poetry.lock" ]; then
       poetry lock --no-update --quiet --no-interaction
     fi
@@ -141,9 +144,11 @@ snyk_setupfile(){
     use_custom
   elif ! [[ -f "requirements.txt" ]]; then
     pip install --quiet -U -e ./ && pip --quiet freeze > requirements.txt
+
+    # Only need to run Snyk if there was not requirements.txt file
+    run_snyk "${manifest}" "pip" "${prefix}/${manifest}"
   fi
 
-  run_snyk "${manifest}" "pip" "${prefix}/${manifest}"
   deactivate
   
   cd "${BASE}" || exit


### PR DESCRIPTION
There were a couple issues with how snyk-bulk was handling python manifests

It was assuming all pyproject.toml files were for poetry projects but that's not always the case. Sometimes it's used with a requirements.txt and setup.py and just has project metadata.

I added a check to look for `[tool.poetry]` in the pyproject.toml to confirm its for a poetry project.

Also, its trying to run snyk on every setup.py file, even if it also has a requirements.txt file. Since we're also scanning requirements.txt separately this will lead to duplicates. I changed it to only run a snyk scan of setup.py when there was no requirements.txt present in that folder.