### PR TITLE
Skip Maven install dependency check

### DIFF
--- a/entrypoints/maven.sh
+++ b/entrypoints/maven.sh
@@ -28,9 +28,7 @@ snyk_pomfile(){
   if [[ -f ".snyk.d/prep.sh" ]]; then
     use_custom
   else
-    # something there
-    
-    (mvn install -DskipTests -DskipIntegrationsTests=true -DskipDocker=true -Ddocker.skip=true -Dmaven.test.skip=true -Denforcer.fail=false -Dscope=runtime --fail-never) &>> "${SNYK_LOG_FILE}"
+    (mvn install -DskipTests -DskipIntegrationsTests=true -DskipDocker=true -Ddocker.skip=true -Dmaven.test.skip=true -DskipDependencyCheck=true -Denforcer.fail=false -Dscope=runtime --fail-never) &>> "${SNYK_LOG_FILE}"
 
   fi
 


### PR DESCRIPTION
Difficult to see in the diff, but added the following flag. This dependency check calls to the NVD api to get vulnerability data for each dependency. We don't need this and skipping it will speed up the install

```
-DskipDependencyCheck=true
```


